### PR TITLE
Fix type of `SUPPORTED_ROLES` in dictionaries widget

### DIFF
--- a/news.d/bugfix/1854.ui.md
+++ b/news.d/bugfix/1854.ui.md
@@ -1,0 +1,1 @@
+Fix `_pythonToCppCopy: Cannot copy-convert <set> to C++` warnings on startup.

--- a/plover/gui_qt/dictionaries_widget.py
+++ b/plover/gui_qt/dictionaries_widget.py
@@ -101,13 +101,13 @@ class DictionariesModel(QAbstractListModel):
         def is_loaded(self):
             return self.state not in {"loading", "error"}
 
-    SUPPORTED_ROLES = {
+    SUPPORTED_ROLES = [
         Qt.ItemDataRole.AccessibleTextRole,
         Qt.ItemDataRole.CheckStateRole,
         Qt.ItemDataRole.DecorationRole,
         Qt.ItemDataRole.DisplayRole,
         Qt.ItemDataRole.ToolTipRole,
-    }
+    ]
 
     FLAGS = (
         Qt.ItemFlag.ItemIsEnabled

--- a/test/gui_qt/test_dictionaries_widget.py
+++ b/test/gui_qt/test_dictionaries_widget.py
@@ -35,12 +35,9 @@ ENABLED_TO_CHAR = {
 }
 ENABLED_FROM_CHAR = {c: e for e, c in ENABLED_TO_CHAR.items()}
 
-# TODO what does it mean that the MODEL_ROLES are now empty?
-MODEL_ROLES = []
-# before PySide6 refactoring:
-# MODEL_ROLES = sorted([Qt.ItemDataRole.AccessibleTextRole, Qt.ItemDataRole.CheckStateRole,
-#                      Qt.ItemDataRole.DecorationRole, Qt.ItemDataRole.DisplayRole,
-#                      Qt.ItemDataRole.ToolTipRole])
+MODEL_ROLES = sorted([Qt.ItemDataRole.AccessibleTextRole, Qt.ItemDataRole.CheckStateRole,
+                     Qt.ItemDataRole.DecorationRole, Qt.ItemDataRole.DisplayRole,
+                     Qt.ItemDataRole.ToolTipRole])
 
 
 def parse_state(state_str):

--- a/test/gui_qt/test_dictionaries_widget.py
+++ b/test/gui_qt/test_dictionaries_widget.py
@@ -35,9 +35,15 @@ ENABLED_TO_CHAR = {
 }
 ENABLED_FROM_CHAR = {c: e for e, c in ENABLED_TO_CHAR.items()}
 
-MODEL_ROLES = sorted([Qt.ItemDataRole.AccessibleTextRole, Qt.ItemDataRole.CheckStateRole,
-                     Qt.ItemDataRole.DecorationRole, Qt.ItemDataRole.DisplayRole,
-                     Qt.ItemDataRole.ToolTipRole])
+MODEL_ROLES = sorted(
+    [
+        Qt.ItemDataRole.AccessibleTextRole,
+        Qt.ItemDataRole.CheckStateRole,
+        Qt.ItemDataRole.DecorationRole,
+        Qt.ItemDataRole.DisplayRole,
+        Qt.ItemDataRole.ToolTipRole,
+    ]
+)
 
 
 def parse_state(state_str):


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://github.com/openstenoproject/plover/blob/main/doc/developer_guide.md! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Send a list, not a set, as in the official PySide repository:

https://github.com/qtproject/pyside-pyside-setup/blob/6389b54051d11154bb26874af1351dfa82c9d66e/examples/widgets/tutorials/modelview/3_changingmodel.py#L44

- Closes #1853.

## Tests

I confirmed that the startup error log was suppressed after this change.

> I manually tested it with `plover-flake`:
> 
> ```
> nix run .#plover-full --override-input plover path:./local-plover-with-fix
> ```

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/main/doc/developer_guide.md#making-a-pull-request) for details
