### PR TITLE
Treat unbound keys as no-op

### DIFF
--- a/news.d/bugfix/1850.core.md
+++ b/news.d/bugfix/1850.core.md
@@ -1,0 +1,1 @@
+Treat unbound keys as no-op.

--- a/news.d/bugfix/1850.dict
+++ b/news.d/bugfix/1850.dict
@@ -1,1 +1,0 @@
-Treat unbound keys as no-op

--- a/news.d/bugfix/1850.dict
+++ b/news.d/bugfix/1850.dict
@@ -1,0 +1,1 @@
+Treat unbound keys as no-op

--- a/plover/machine/keymap.py
+++ b/plover/machine/keymap.py
@@ -93,7 +93,7 @@ class Keymap:
         action_list = []
         for key in key_list:
             assert key in self._keys, "'%s' not in %s" % (key, self._keys)
-            action = self._bindings[key]
+            action = self._bindings.get(key, "no-op")
             if "no-op" != action:
                 action_list.append(action)
         return action_list

--- a/test/test_keymap.py
+++ b/test/test_keymap.py
@@ -58,6 +58,18 @@ def test_keymap_set_mappings():
     assert k.get_mappings() == MAPPINGS_FULL
 
 
+def test_keymap_keys_to_actions_for_unbound_key():
+    # An unbound key is treated as no-op.
+    k = new_keymap()
+    k.set_bindings(BINDINGS_DICT)
+    assert "k2" not in k.get_bindings()
+    assert k.keys_to_actions(["k0", "k2", "k4"]) == ["a0", "a1"]
+    # If the machine emits a key out of range, it's an error:
+    with pytest.raises(AssertionError):
+        # AssertionError: 'k9' not in OrderedDict({...})
+        k.keys_to_actions(["k9"])
+
+
 def test_keymap_setitem():
     bindings = dict(BINDINGS_DICT)
     mappings = dict(MAPPINGS_FULL)


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://github.com/openstenoproject/plover/blob/main/doc/developer_guide.md! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Treat unbound keys as no-op. It's _slightly_ kinder to machine developers.

Closes #1850, #1629 <!-- issue number here -->

- If the user machine emits a key out of range, it would still fail like `AssertionError: 'k9' not in OrderedDict({...})`. Maybe that's ok for now.

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/main/doc/developer_guide.md#making-a-pull-request) for details
