### PR TITLE
fix: show_error no longer crashes on failed startup

### DIFF
--- a/news.d/bugfix/1863.ui.md
+++ b/news.d/bugfix/1863.ui.md
@@ -1,0 +1,1 @@
+Fix a crash when showing an error dialog during a failed startup.

--- a/plover/gui_qt/main.py
+++ b/plover/gui_qt/main.py
@@ -86,9 +86,13 @@ class Application:
 
 def show_error(title, message):
     print(f"{title}: {message}")
-    app = QApplication([])
+    app = QApplication.instance()
+    owns_app = app is None
+    if owns_app:
+        app = QApplication([])
     QMessageBox.critical(None, title, message)
-    del app
+    if owns_app:
+        del app
 
 
 def default_excepthook(*exc_info):

--- a/plover/gui_qt/main.py
+++ b/plover/gui_qt/main.py
@@ -86,13 +86,9 @@ class Application:
 
 def show_error(title, message):
     print(f"{title}: {message}")
-    app = QApplication.instance()
-    owns_app = app is None
-    if owns_app:
-        app = QApplication([])
+    if QApplication.instance() is None:
+        QApplication([])
     QMessageBox.critical(None, title, message)
-    if owns_app:
-        del app
 
 
 def default_excepthook(*exc_info):


### PR DESCRIPTION
## Summary of changes

If the app crashes while the application is being initialized, like in the following case:

```
❯ nix run .#plover_5
Unexpected error: Traceback (most recent call last):
  File "/nix/store/nfk0rwvw8lgm1yymbdr7ynxznrlbwzfw-python3.14-plover-5.4.0/lib/python3.14/site-packages/plover/scripts/main.py", line 150, in main
    code = gui.main(config, controller)
  File "/nix/store/nfk0rwvw8lgm1yymbdr7ynxznrlbwzfw-python3.14-plover-5.4.0/lib/python3.14/site-packages/plover/gui_qt/main.py", line 125, in main
    app = Application(config, controller, use_qt_notifications)
  File "/nix/store/nfk0rwvw8lgm1yymbdr7ynxznrlbwzfw-python3.14-plover-5.4.0/lib/python3.14/site-packages/plover/gui_qt/main.py", line 61, in __init__
    config, controller, KeyboardEmulation()
                        ~~~~~~~~~~~~~~~~~^^
  File "/nix/store/nfk0rwvw8lgm1yymbdr7ynxznrlbwzfw-python3.14-plover-5.4.0/lib/python3.14/site-packages/plover/oslayer/linux/keyboardcontrol_uinput.py", line 76, in __init__
    self._ui = UInput(res)
               ~~~~~~^^^^^
  File "/nix/store/5hcr44a0jk8zxfwxzd18s4lcn5abrv0i-python3.14-evdev-1.9.3/lib/python3.14/site-packages/evdev/uinput.py", line 152, in __init__
    self._verify()
    ~~~~~~~~~~~~^^
  File "/nix/store/5hcr44a0jk8zxfwxzd18s4lcn5abrv0i-python3.14-evdev-1.9.3/lib/python3.14/site-packages/evdev/uinput.py", line 285, in _verify
    raise UInputError(msg.format(self.devnode))
evdev.uinput.UInputError: "/dev/uinput" cannot be opened for writing

2026-08-06 19:22:17,873 [MainThread] ERROR: Qt GUI error
Traceback (most recent call last):
  File "/nix/store/nfk0rwvw8lgm1yymbdr7ynxznrlbwzfw-python3.14-plover-5.4.0/lib/python3.14/site-packages/plover/scripts/main.py", line 150, in main
    code = gui.main(config, controller)
  File "/nix/store/nfk0rwvw8lgm1yymbdr7ynxznrlbwzfw-python3.14-plover-5.4.0/lib/python3.14/site-packages/plover/gui_qt/main.py", line 125, in main
    app = Application(config, controller, use_qt_notifications)
  File "/nix/store/nfk0rwvw8lgm1yymbdr7ynxznrlbwzfw-python3.14-plover-5.4.0/lib/python3.14/site-packages/plover/gui_qt/main.py", line 61, in __init__
    config, controller, KeyboardEmulation()
                        ~~~~~~~~~~~~~~~~~^^
  File "/nix/store/nfk0rwvw8lgm1yymbdr7ynxznrlbwzfw-python3.14-plover-5.4.0/lib/python3.14/site-packages/plover/oslayer/linux/keyboardcontrol_uinput.py", line 76, in __init__
    self._ui = UInput(res)
               ~~~~~~^^^^^
  File "/nix/store/5hcr44a0jk8zxfwxzd18s4lcn5abrv0i-python3.14-evdev-1.9.3/lib/python3.14/site-packages/evdev/uinput.py", line 152, in __init__
    self._verify()
    ~~~~~~~~~~~~^^
  File "/nix/store/5hcr44a0jk8zxfwxzd18s4lcn5abrv0i-python3.14-evdev-1.9.3/lib/python3.14/site-packages/evdev/uinput.py", line 285, in _verify
    raise UInputError(msg.format(self.devnode))
evdev.uinput.UInputError: "/dev/uinput" cannot be opened for writing

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/nix/store/nfk0rwvw8lgm1yymbdr7ynxznrlbwzfw-python3.14-plover-5.4.0/bin/.plover-wrapped", line 9, in <module>
    sys.exit(main())
             ~~~~^^
  File "/nix/store/nfk0rwvw8lgm1yymbdr7ynxznrlbwzfw-python3.14-plover-5.4.0/lib/python3.14/site-packages/plover/scripts/main.py", line 170, in main
    gui.show_error("Unexpected error", traceback.format_exc())
    ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/nfk0rwvw8lgm1yymbdr7ynxznrlbwzfw-python3.14-plover-5.4.0/lib/python3.14/site-packages/plover/gui_qt/main.py", line 90, in show_error
    app = QApplication([])
RuntimeError: libshiboken: Please destroy the QApplication singleton before creating a new QApplication instance.
```

then an application instance already exists, and so when show_error tries to open its own dialog, it can't because there's already a `QApplication` instance.

### Pull Request Checklist

- [ ] Changes have tests
- [x] News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/main/doc/developer_guide.md#making-a-pull-request) for details
