### PR TITLE
downgrade InvalidReport from logging error to debug

### DIFF
--- a/plover/machine/plover_hid.py
+++ b/plover/machine/plover_hid.py
@@ -245,7 +245,7 @@ class PloverHid(ThreadedStenotypeBase):
             try:
                 current = self._parse(report)
             except InvalidReport:
-                log.error("invalid report")
+                log.debug("Invalid Plover HID report.")
                 continue
 
             press_started = time.time()


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://github.com/openstenoproject/plover/blob/main/doc/developer_guide.md! -->
<!-- Remove sections if not applicable -->

## Summary of changes

I have a keyboard that switches between PloverHID and mouse keys.

On Windows, I can use PloverHID and switch with the mouse keys with no errors. 

On Linux, I get the invalid report error if I try to use mouse keys.

In Linux, HID devices share the same path even though they may have multiple usage and usage pages (unlike Windows which seems to generate unique paths). Plover will attempt to read non-PloverHID data packets (mousekey events in my case), and raise InvalidReport errors, generating multiple system notifications. 

The change in log level will stop the notifications, but debug output will still show the exception.

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in news.d. See [documentation](https://github.com/openstenoproject/plover/blob/main/doc/developer_guide.md#making-a-pull-request) for details
